### PR TITLE
chore: add missing metadata in package.json

### DIFF
--- a/ember-is-component/package.json
+++ b/ember-is-component/package.json
@@ -1,13 +1,22 @@
 {
   "name": "ember-is-component",
   "version": "0.0.0",
-  "description": "The default blueprint for Embroider v2 addons.",
+  "description": "Provides a helper to check if a component exists.",
   "keywords": [
-    "ember-addon"
+    "ember",
+    "emberjs",
+    "ember-addon",
+    "is-component",
+    "helper"
   ],
-  "repository": "",
+  "homepage": "https://github.com/BlueCutOfficial/ember-is-component",
+  "repository": "https://github.com/BlueCutOfficial/ember-is-component",
+  "bugs": "https://github.com/BlueCutOfficial/ember-is-component/issues",
   "license": "MIT",
-  "author": "",
+  "author": {
+    "name": "Marine Dunstetter",
+    "url": "https://github.com/BlueCutOfficial"
+  },
   "files": [
     "addon-main.cjs",
     "dist"


### PR DESCRIPTION
This PR adds missing metadata in the package.json.
There are going to be used in the npmjs details page https://www.npmjs.com/package/ember-is-component